### PR TITLE
feat: 26.1 support & more item groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Build output
+target/
+
+# IDEs
+.idea/
+.vscode/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Logs
+logs/
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ Thumbs.db
 
 # Logs
 logs/
-*.log
+*.log 

--- a/src/main/java/com/codingguru/inventorystacks/InventoryStacks.java
+++ b/src/main/java/com/codingguru/inventorystacks/InventoryStacks.java
@@ -15,6 +15,7 @@ import com.codingguru.inventorystacks.listeners.correction.PlayerItemConsume;
 import com.codingguru.inventorystacks.listeners.general.BlockPlace;
 import com.codingguru.inventorystacks.listeners.general.Commands;
 import com.codingguru.inventorystacks.listeners.general.PlayerItemDamage;
+import com.codingguru.inventorystacks.listeners.general.TotemOffhandLimit;
 import com.codingguru.inventorystacks.listeners.itemmeta.UpdateItemMetaListener;
 import com.codingguru.inventorystacks.managers.SettingsManager;
 import com.codingguru.inventorystacks.util.ConsoleUtil;
@@ -52,6 +53,7 @@ public class InventoryStacks extends JavaPlugin {
 		getServer().getPluginManager().registerEvents(new Commands(), this);
 		getServer().getPluginManager().registerEvents(new PlayerItemDamage(itemChangeDelay), this);
 		getServer().getPluginManager().registerEvents(new BlockPlace(itemChangeDelay), this);
+		getServer().getPluginManager().registerEvents(new TotemOffhandLimit(), this);
 
 		if (ItemHandler.getInstance().isUsingModernAPI()) {
 			getServer().getPluginManager().registerEvents(new UpdateItemMetaListener(), this);

--- a/src/main/java/com/codingguru/inventorystacks/handlers/ItemHandler.java
+++ b/src/main/java/com/codingguru/inventorystacks/handlers/ItemHandler.java
@@ -34,6 +34,8 @@ public class ItemHandler {
 
 	private final Map<XMaterialUtil, Integer> cachedDefaultStackSizes = Maps.newHashMap();
 	private final Map<XMaterialUtil, Integer> cachedUpdatedStackSizes = Maps.newHashMap();
+	private final Map<Material, Integer> cachedUpdatedDirectMaterialSizes = Maps.newHashMap();
+	private final Set<String> loggedUnsupportedMaterials = new HashSet<>();
 
 	private VersionUtil serverVersion;
 	private ServerTypeUtil serverType;
@@ -132,21 +134,33 @@ public class ItemHandler {
 	}
 
 	public boolean hasUpdatedStack(ItemStack stack) {
-		XMaterialUtil xMat = matchXMaterialSafely(stack);
-
-		if (xMat == null)
+		if (stack == null || stack.getType() == Material.AIR)
 			return false;
 
-		return cachedUpdatedStackSizes.containsKey(xMat);
+		XMaterialUtil xMat = matchXMaterialSafely(stack);
+
+		if (xMat != null)
+			return cachedUpdatedStackSizes.containsKey(xMat);
+
+		return cachedUpdatedDirectMaterialSizes.containsKey(stack.getType());
 	}
 
 	public void applyItem(boolean isStartUp, ItemStack stack) {
-		XMaterialUtil xMat = matchXMaterialSafely(stack);
-
-		if (xMat == null)
+		if (stack == null || stack.getType() == Material.AIR)
 			return;
 
-		Integer amount = cachedUpdatedStackSizes.get(xMat);
+		XMaterialUtil xMat = matchXMaterialSafely(stack);
+
+		if (xMat != null) {
+			Integer amount = cachedUpdatedStackSizes.get(xMat);
+			if (amount == null)
+				return;
+
+			applier.applyItem(isStartUp, stack, amount);
+			return;
+		}
+
+		Integer amount = cachedUpdatedDirectMaterialSizes.get(stack.getType());
 		if (amount == null)
 			return;
 
@@ -156,24 +170,51 @@ public class ItemHandler {
 	private XMaterialUtil matchXMaterialSafely(ItemStack stack) {
 		try {
 			return XMaterialUtil.matchXMaterial(stack);
-		} catch (IllegalArgumentException ignored) {
+		} catch (IllegalArgumentException ex) {
+			debugUnsupportedMaterial(stack.getType(), ex);
 			return null;
 		}
+	}
+
+	private XMaterialUtil matchXMaterialSafely(Material material) {
+		try {
+			return XMaterialUtil.matchXMaterial(material);
+		} catch (IllegalArgumentException ex) {
+			debugUnsupportedMaterial(material, ex);
+			return null;
+		}
+	}
+
+	private void debugUnsupportedMaterial(Material material, Exception ex) {
+		if (material == null)
+			return;
+
+		String key = material.name().toUpperCase();
+
+		if (!loggedUnsupportedMaterials.add(key))
+			return;
+
+		ConsoleUtil.debug("Unsupported XMaterial mapping detected for '" + material.name()
+				+ "' on server version " + getServerVersion() + ". Falling back to direct Material handling.");
+		ConsoleUtil.debug("Root cause: " + ex.getMessage());
 	}
 
 	public boolean hasEditedStackSize(Material material) {
 		if (material == Material.AIR)
 			return false;
 
-		XMaterialUtil xMaterial = XMaterialUtil.matchXMaterial(material);
+		XMaterialUtil xMaterial = matchXMaterialSafely(material);
 
-		if (xMaterial == null)
-			return false;
+		if (xMaterial != null)
+			return hasEditedStackSize(xMaterial);
 
-		return hasEditedStackSize(xMaterial);
+		return cachedUpdatedDirectMaterialSizes.containsKey(material);
 	}
 
 	public boolean hasEditedStackSize(XMaterialUtil xMaterial) {
+		if (xMaterial == null)
+			return false;
+
 		return cachedUpdatedStackSizes.containsKey(xMaterial);
 	}
 
@@ -186,10 +227,19 @@ public class ItemHandler {
 		cachedDefaultStackSizes.putIfAbsent(xMaterial, oldStackSize);
 	}
 
+	public void cacheMaterialStackSize(Material material, int newStackSize) {
+		if (material == null || material == Material.AIR)
+			return;
+
+		cachedUpdatedDirectMaterialSizes.putIfAbsent(material, newStackSize);
+	}
+
 	public void reloadInventoryStacks() {
 		resetMaterialsToDefaultValues();
 		cachedDefaultStackSizes.clear();
 		cachedUpdatedStackSizes.clear();
+		cachedUpdatedDirectMaterialSizes.clear();
+		loggedUnsupportedMaterials.clear();
 		applyConfiguredStacks();
 	}
 
@@ -206,8 +256,18 @@ public class ItemHandler {
 				XMaterialUtil xMat = XMaterialUtil.matchXMaterial(matName).orElse(null);
 
 				if (xMat == null) {
-					ConsoleUtil.warning(ChatColor.RED + "The Item: " + matName
-							+ " does not exist. Check MATERIAL_LIST.txt for all up to date item names.");
+					Material directMaterial = resolveMaterialByName(matName);
+
+					if (directMaterial == null || !isItem(directMaterial)) {
+						ConsoleUtil.warning(ChatColor.RED + "The Item: " + matName
+								+ " does not exist. Check MATERIAL_LIST.txt for all up to date item names.");
+						continue;
+					}
+
+					cacheMaterialStackSize(directMaterial, size);
+					applier.applyItem(true, new ItemStack(directMaterial), size);
+					ConsoleUtil.info(ChatColor.YELLOW + "Successfully set " + directMaterial.name() + " stack size to: " + size
+							+ " (direct Material fallback)");
 					continue;
 				}
 
@@ -235,6 +295,26 @@ public class ItemHandler {
 
 			updateAllItems(exemptMaterials, stackSize);
 		}
+	}
+
+	private Material resolveMaterialByName(String materialName) {
+		if (materialName == null || materialName.trim().isEmpty())
+			return null;
+
+		String normalized = materialName.trim().toUpperCase();
+
+		Material matched = Material.getMaterial(normalized);
+		if (matched != null)
+			return matched;
+
+		matched = Material.matchMaterial(materialName);
+		if (matched != null)
+			return matched;
+
+		if (!normalized.startsWith("MINECRAFT:"))
+			return null;
+
+		return Material.matchMaterial(normalized.substring("MINECRAFT:".length()));
 	}
 
 	private Map<String, Integer> resolveConfiguredItems(Collection<String> keys) {
@@ -321,6 +401,22 @@ public class ItemHandler {
 			cacheMaterialStackSize(xMat, stackSize, mat.getMaxStackSize());
 			applier.applyItem(true, xMat.parseItem(), stackSize);
 			ConsoleUtil.info(ChatColor.YELLOW + "Successfully set " + mat.name() + " stack size to: " + stackSize);
+		}
+
+		for (Material mat : Material.values()) {
+			if (mat == null || !isItem(mat))
+				continue;
+
+			if (exemptMaterials.contains(mat.name().toUpperCase()))
+				continue;
+
+			if (!processed.add(mat))
+				continue;
+
+			cacheMaterialStackSize(mat, stackSize);
+			applier.applyItem(true, new ItemStack(mat), stackSize);
+			ConsoleUtil.info(ChatColor.YELLOW + "Successfully set " + mat.name() + " stack size to: " + stackSize
+					+ " (direct Material fallback)");
 		}
 	}
 

--- a/src/main/java/com/codingguru/inventorystacks/handlers/ItemHandler.java
+++ b/src/main/java/com/codingguru/inventorystacks/handlers/ItemHandler.java
@@ -132,7 +132,7 @@ public class ItemHandler {
 	}
 
 	public boolean hasUpdatedStack(ItemStack stack) {
-		XMaterialUtil xMat = XMaterialUtil.matchXMaterial(stack);
+		XMaterialUtil xMat = matchXMaterialSafely(stack);
 
 		if (xMat == null)
 			return false;
@@ -141,13 +141,24 @@ public class ItemHandler {
 	}
 
 	public void applyItem(boolean isStartUp, ItemStack stack) {
-		XMaterialUtil xMat = XMaterialUtil.matchXMaterial(stack);
+		XMaterialUtil xMat = matchXMaterialSafely(stack);
 
 		if (xMat == null)
 			return;
 
-		int amount = cachedUpdatedStackSizes.get(xMat);
+		Integer amount = cachedUpdatedStackSizes.get(xMat);
+		if (amount == null)
+			return;
+
 		applier.applyItem(isStartUp, stack, amount);
+	}
+
+	private XMaterialUtil matchXMaterialSafely(ItemStack stack) {
+		try {
+			return XMaterialUtil.matchXMaterial(stack);
+		} catch (IllegalArgumentException ignored) {
+			return null;
+		}
 	}
 
 	public boolean hasEditedStackSize(Material material) {

--- a/src/main/java/com/codingguru/inventorystacks/handlers/ItemHandler.java
+++ b/src/main/java/com/codingguru/inventorystacks/handlers/ItemHandler.java
@@ -84,6 +84,10 @@ public class ItemHandler {
 		String majorMinor = parts[0] + "." + parts[1];
 
 		if (versionFound.equalsIgnoreCase("craftbukkit")) {
+			if (majorMinor.equals("26.1") || majorMinor.equals("1.26")) {
+				serverVersion = VersionUtil.v1_26;
+				return true;
+			}
 			if (majorMinor.equals("1.21")) {
 				serverVersion = VersionUtil.v1_21;
 				return true;
@@ -237,11 +241,12 @@ public class ItemHandler {
 				continue;
 
 			int stackSize = validateStackSize(PLUGIN.getConfig().getInt("items." + key), key);
+			String patternInput = resolveItemGroupPattern(key);
 
 			final Pattern pattern;
 
 			try {
-				pattern = Pattern.compile(key, Pattern.CASE_INSENSITIVE);
+				pattern = Pattern.compile(patternInput, Pattern.CASE_INSENSITIVE);
 			} catch (PatternSyntaxException ex) {
 				ConsoleUtil.warning(ChatColor.RED + "Invalid regex in items: '" + key + "': " + ex.getDescription());
 				continue;
@@ -257,6 +262,30 @@ public class ItemHandler {
 		}
 
 		return resolved;
+	}
+
+	private String resolveItemGroupPattern(String key) {
+		String normalized = key.trim().toUpperCase();
+
+		switch (normalized) {
+		case "BEDS":
+		case "BED":
+			return "^.*_BED$";
+		case "POTIONS":
+		case "POTION":
+			return "^(POTION|SPLASH_POTION|LINGERING_POTION)$";
+		case "STEWS":
+		case "STEW":
+			return "^(MUSHROOM_STEW|RABBIT_STEW|SUSPICIOUS_STEW|BEETROOT_SOUP)$";
+		case "BUCKETS":
+		case "BUCKET":
+			return "^(BUCKET|.*_BUCKET)$";
+		case "BOATS":
+		case "BOAT":
+			return "^(.*_BOAT|.*_CHEST_BOAT|.*_RAFT|.*_CHEST_RAFT)$";
+		default:
+			return key;
+		}
 	}
 
 	private void updateAllItems(Set<String> exemptMaterials, int stackSize) {

--- a/src/main/java/com/codingguru/inventorystacks/handlers/ItemHandler.java
+++ b/src/main/java/com/codingguru/inventorystacks/handlers/ItemHandler.java
@@ -23,7 +23,7 @@ import com.codingguru.inventorystacks.util.ReflectionLegacyUtil;
 import com.codingguru.inventorystacks.util.ServerTypeUtil;
 import com.codingguru.inventorystacks.util.StackSizeApplierUtil;
 import com.codingguru.inventorystacks.util.VersionUtil;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 import com.google.common.collect.Maps;
 
 @SuppressWarnings("deprecation")
@@ -32,8 +32,8 @@ public class ItemHandler {
 	private static final ItemHandler INSTANCE = new ItemHandler();
 	private final static InventoryStacks PLUGIN = InventoryStacks.getInstance();
 
-	private final Map<XMaterial, Integer> cachedDefaultStackSizes = Maps.newHashMap();
-	private final Map<XMaterial, Integer> cachedUpdatedStackSizes = Maps.newHashMap();
+	private final Map<XMaterialUtil, Integer> cachedDefaultStackSizes = Maps.newHashMap();
+	private final Map<XMaterialUtil, Integer> cachedUpdatedStackSizes = Maps.newHashMap();
 
 	private VersionUtil serverVersion;
 	private ServerTypeUtil serverType;
@@ -132,7 +132,7 @@ public class ItemHandler {
 	}
 
 	public boolean hasUpdatedStack(ItemStack stack) {
-		XMaterial xMat = XMaterial.matchXMaterial(stack);
+		XMaterialUtil xMat = XMaterialUtil.matchXMaterial(stack);
 
 		if (xMat == null)
 			return false;
@@ -141,7 +141,7 @@ public class ItemHandler {
 	}
 
 	public void applyItem(boolean isStartUp, ItemStack stack) {
-		XMaterial xMat = XMaterial.matchXMaterial(stack);
+		XMaterialUtil xMat = XMaterialUtil.matchXMaterial(stack);
 
 		if (xMat == null)
 			return;
@@ -154,7 +154,7 @@ public class ItemHandler {
 		if (material == Material.AIR)
 			return false;
 
-		XMaterial xMaterial = XMaterial.matchXMaterial(material);
+		XMaterialUtil xMaterial = XMaterialUtil.matchXMaterial(material);
 
 		if (xMaterial == null)
 			return false;
@@ -162,11 +162,11 @@ public class ItemHandler {
 		return hasEditedStackSize(xMaterial);
 	}
 
-	public boolean hasEditedStackSize(XMaterial xMaterial) {
+	public boolean hasEditedStackSize(XMaterialUtil xMaterial) {
 		return cachedUpdatedStackSizes.containsKey(xMaterial);
 	}
 
-	public void cacheMaterialStackSize(XMaterial xMaterial, int newStackSize, int oldStackSize) {
+	public void cacheMaterialStackSize(XMaterialUtil xMaterial, int newStackSize, int oldStackSize) {
 		cachedUpdatedStackSizes.putIfAbsent(xMaterial, newStackSize);
 
 		if (applier.isModernApi()) // no need to cache default stack size
@@ -192,7 +192,7 @@ public class ItemHandler {
 				String matName = e.getKey();
 				int size = e.getValue();
 
-				XMaterial xMat = XMaterial.matchXMaterial(matName).orElse(null);
+				XMaterialUtil xMat = XMaterialUtil.matchXMaterial(matName).orElse(null);
 
 				if (xMat == null) {
 					ConsoleUtil.warning(ChatColor.RED + "The Item: " + matName
@@ -228,7 +228,7 @@ public class ItemHandler {
 
 	private Map<String, Integer> resolveConfiguredItems(Collection<String> keys) {
 		Map<String, Integer> resolved = new HashMap<>();
-		XMaterial[] allMaterials = XMaterial.VALUES;
+		XMaterialUtil[] allMaterials = XMaterialUtil.VALUES;
 
 		for (String key : keys) {
 			if (key == null)
@@ -252,7 +252,7 @@ public class ItemHandler {
 				continue;
 			}
 
-			for (XMaterial material : allMaterials) {
+			for (XMaterialUtil material : allMaterials) {
 				String name = material.name();
 
 				if (pattern.matcher(name).matches()) {
@@ -291,7 +291,7 @@ public class ItemHandler {
 	private void updateAllItems(Set<String> exemptMaterials, int stackSize) {
 		Set<Material> processed = new HashSet<>();
 
-		for (XMaterial xMat : XMaterial.VALUES) {
+		for (XMaterialUtil xMat : XMaterialUtil.VALUES) {
 			if (!xMat.isSupported())
 				continue;
 
@@ -346,7 +346,7 @@ public class ItemHandler {
 		if (applier.isModernApi())
 			return;
 
-		for (Map.Entry<XMaterial, Integer> entry : cachedDefaultStackSizes.entrySet()) {
+		for (Map.Entry<XMaterialUtil, Integer> entry : cachedDefaultStackSizes.entrySet()) {
 			int defaultSize = entry.getValue();
 			applier.applyItem(true, entry.getKey().parseItem(), defaultSize);
 		}

--- a/src/main/java/com/codingguru/inventorystacks/handlers/ItemHandler.java
+++ b/src/main/java/com/codingguru/inventorystacks/handlers/ItemHandler.java
@@ -68,6 +68,10 @@ public class ItemHandler {
 				+ ItemHandler.getInstance().getServerType().toString());
 		ConsoleUtil.message(ChatColor.GREEN + "Stack Sizing Mode: " + ChatColor.YELLOW
 				+ (applier.isModernApi() ? "ItemMeta API (1.20.5+)" : "Legacy NMS"));
+		if (StackSizeApplierUtil.isGeyserCompatibilityEnabled() && StackSizeApplierUtil.isGeyserPresent()) {
+			ConsoleUtil.message(ChatColor.GREEN + "Geyser/Floodgate Support: " + ChatColor.YELLOW
+					+ "enabled (using Legacy NMS for Bedrock compatibility)");
+		}
 		ConsoleUtil.message("");
 
 		applyConfiguredStacks();
@@ -234,6 +238,19 @@ public class ItemHandler {
 		cachedUpdatedDirectMaterialSizes.putIfAbsent(material, newStackSize);
 	}
 
+	@Deprecated
+	public void cacheMaterial(XMaterialUtil xMaterial, int oldStackSize) {
+		if (xMaterial == null)
+			return;
+
+		cachedDefaultStackSizes.putIfAbsent(xMaterial, oldStackSize);
+	}
+
+	@Deprecated
+	public void applyStackSizeToNmsItem(Object nmsItem, int size) {
+		ReflectionLegacyUtil.applyStackSizeToNmsItem(nmsItem, Material.AIR, size);
+	}
+
 	public void reloadInventoryStacks() {
 		resetMaterialsToDefaultValues();
 		cachedDefaultStackSizes.clear();
@@ -350,6 +367,17 @@ public class ItemHandler {
 					resolved.putIfAbsent(name.toUpperCase(), stackSize);
 				}
 			}
+
+			for (Material material : Material.values()) {
+				if (material == null || !isItem(material))
+					continue;
+
+				String name = material.name();
+
+				if (pattern.matcher(name).matches()) {
+					resolved.putIfAbsent(name.toUpperCase(), stackSize);
+				}
+			}
 		}
 
 		return resolved;
@@ -374,6 +402,71 @@ public class ItemHandler {
 		case "BOATS":
 		case "BOAT":
 			return "^(.*_BOAT|.*_CHEST_BOAT|.*_RAFT|.*_CHEST_RAFT)$";
+		case "MINECARTS":
+		case "MINECART":
+			return "^(MINECART|.*_MINECART)$";
+		case "TOOLS":
+		case "TOOL":
+			return "^(SHEARS|FISHING_ROD|BRUSH|FLINT_AND_STEEL|.*_(PICKAXE|AXE|SHOVEL|HOE))$";
+		case "WEAPONS":
+		case "WEAPON":
+			return "^(BOW|CROSSBOW|TRIDENT|MACE|.*_SWORD|.*_AXE)$";
+		case "ARMOR":
+			return "^(ELYTRA|TURTLE_HELMET|.*_(HELMET|CHESTPLATE|LEGGINGS|BOOTS|HORSE_ARMOR))$";
+		case "HORSE_ARMOR":
+			return "^.*_HORSE_ARMOR$";
+		case "DYES":
+		case "DYE":
+			return "^.*_DYE$";
+		case "SIGNS":
+		case "SIGN":
+			return "^.*(_SIGN|_HANGING_SIGN)$";
+		case "DOORS":
+		case "DOOR":
+			return "^.*_DOOR$";
+		case "TRAPDOORS":
+		case "TRAPDOOR":
+			return "^.*_TRAPDOOR$";
+		case "BUTTONS":
+		case "BUTTON":
+			return "^.*_BUTTON$";
+		case "PRESSURE_PLATES":
+		case "PRESSURE_PLATE":
+			return "^.*_PRESSURE_PLATE$";
+		case "FENCES":
+		case "FENCE":
+			return "^.*(_FENCE|_FENCE_GATE)$";
+		case "SLABS":
+		case "SLAB":
+			return "^.*_SLAB$";
+		case "STAIRS":
+		case "STAIR":
+			return "^.*_STAIRS$";
+		case "WALLS":
+		case "WALL":
+			return "^.*_WALL$";
+		case "CARPETS":
+		case "CARPET":
+			return "^.*_CARPET$";
+		case "BANNERS":
+		case "BANNER":
+			return "^.*_BANNER$";
+		case "MUSIC_DISCS":
+		case "MUSIC_DISC":
+		case "DISCS":
+		case "DISC":
+			return "^MUSIC_DISC_.*$";
+		case "SPAWN_EGGS":
+		case "SPAWN_EGG":
+			return "^.*_SPAWN_EGG$";
+		case "ARROWS":
+		case "ARROW":
+			return "^(ARROW|SPECTRAL_ARROW|TIPPED_ARROW)$";
+		case "FIREWORKS":
+		case "FIREWORK":
+			return "^(FIREWORK_ROCKET|FIREWORK_STAR)$";
+		case "FOOD":
+			return "^(APPLE|BAKED_POTATO|BEEF|BEETROOT|BEETROOT_SOUP|BREAD|CARROT|CHICKEN|CHORUS_FRUIT|COD|COOKED_BEEF|COOKED_CHICKEN|COOKED_COD|COOKED_MUTTON|COOKED_PORKCHOP|COOKED_RABBIT|COOKED_SALMON|COOKIE|DRIED_KELP|ENCHANTED_GOLDEN_APPLE|GLOW_BERRIES|GOLDEN_APPLE|GOLDEN_CARROT|HONEY_BOTTLE|MELON_SLICE|MUSHROOM_STEW|MUTTON|POISONOUS_POTATO|PORKCHOP|POTATO|PUFFERFISH|PUMPKIN_PIE|RABBIT|RABBIT_STEW|ROTTEN_FLESH|SALMON|SPIDER_EYE|SUSPICIOUS_STEW|SWEET_BERRIES|TROPICAL_FISH)$";
 		default:
 			return key;
 		}

--- a/src/main/java/com/codingguru/inventorystacks/listeners/BlockDispense.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/BlockDispense.java
@@ -18,7 +18,7 @@ import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionType;
 
 import com.codingguru.inventorystacks.util.VersionUtil;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 
 public class BlockDispense implements Listener {
 
@@ -48,7 +48,7 @@ public class BlockDispense implements Listener {
 
 		e.setCancelled(true);
 
-		Material mud = XMaterial.matchXMaterial("MUD").map(XMaterial::get).orElse(null);
+		Material mud = XMaterialUtil.matchXMaterial("MUD").map(XMaterialUtil::get).orElse(null);
 		if (mud == null)
 			return;
 
@@ -68,7 +68,7 @@ public class BlockDispense implements Listener {
 		inSlot.setAmount(inSlot.getAmount() - 1);
 		inv.setItem(slot, inSlot.getAmount() > 0 ? inSlot : null);
 
-		Material glassBottle = XMaterial.matchXMaterial("GLASS_BOTTLE").map(XMaterial::get).orElse(null);
+		Material glassBottle = XMaterialUtil.matchXMaterial("GLASS_BOTTLE").map(XMaterialUtil::get).orElse(null);
 		if (glassBottle != null) {
 			Map<Integer, ItemStack> overflow = inv.addItem(new ItemStack(glassBottle, 1));
 			overflow.values().forEach(item -> dispenserBlock.getWorld()
@@ -81,7 +81,7 @@ public class BlockDispense implements Listener {
 		if (item == null)
 			return false;
 
-		if (item.getType() != XMaterial.matchXMaterial("POTION").map(XMaterial::get).orElse(null))
+		if (item.getType() != XMaterialUtil.matchXMaterial("POTION").map(XMaterialUtil::get).orElse(null))
 			return false;
 
 		if (!(item.getItemMeta() instanceof PotionMeta))

--- a/src/main/java/com/codingguru/inventorystacks/listeners/BlockPlace.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/BlockPlace.java
@@ -10,7 +10,7 @@ import org.bukkit.inventory.ItemStack;
 
 import com.codingguru.inventorystacks.scheduler.ChangeItemInHandWithItemTask;
 import com.codingguru.inventorystacks.util.VersionUtil;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 
 public class BlockPlace implements Listener {
 
@@ -34,7 +34,7 @@ public class BlockPlace implements Listener {
 			holding = player.getInventory().getItemInOffHand();
 		}
 
-		if (holding.getType() != XMaterial.POWDER_SNOW_BUCKET.get())
+		if (holding.getType() != XMaterialUtil.POWDER_SNOW_BUCKET.get())
 			return;
 
 		int amount = holding.getAmount();
@@ -46,7 +46,7 @@ public class BlockPlace implements Listener {
 		clone.setAmount(amount - 1);
 
 		ChangeItemInHandWithItemTask changeItemTask = new ChangeItemInHandWithItemTask(e.getPlayer(), clone,
-				new ItemStack(XMaterial.BUCKET.get()), XMaterial.BUCKET.get());
+				new ItemStack(XMaterialUtil.BUCKET.get()), XMaterialUtil.BUCKET.get());
 		changeItemTask.runTaskLater(itemChangeDelay);
 	}
 }

--- a/src/main/java/com/codingguru/inventorystacks/listeners/Commands.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/Commands.java
@@ -47,7 +47,7 @@ public class Commands implements Listener {
 
 		XMaterialUtil material = item.get();
 
-		if (!ItemHandler.getInstance().getCachedMaterialSizes().containsKey(material))
+		if (!ItemHandler.getInstance().hasEditedStackSize(material))
 			return;
 
 		if (isDamageable(material.get())) {
@@ -98,7 +98,7 @@ public class Commands implements Listener {
 
 		XMaterialUtil material = item.get();
 
-		if (!ItemHandler.getInstance().getCachedMaterialSizes().containsKey(material))
+		if (!ItemHandler.getInstance().hasEditedStackSize(material))
 			return;
 
 		if (isDamageable(material.get())) {

--- a/src/main/java/com/codingguru/inventorystacks/listeners/Commands.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/Commands.java
@@ -18,7 +18,7 @@ import com.codingguru.inventorystacks.handlers.ItemHandler;
 import com.codingguru.inventorystacks.util.ItemUtil;
 import com.codingguru.inventorystacks.util.MessagesUtil;
 import com.codingguru.inventorystacks.util.RandomUtil;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 import com.google.common.collect.Lists;
 
 public class Commands implements Listener {
@@ -40,12 +40,12 @@ public class Commands implements Listener {
 
 		int amount = Integer.parseInt(command[3]);
 
-		Optional<XMaterial> item = XMaterial.matchXMaterial(itemName);
+		Optional<XMaterialUtil> item = XMaterialUtil.matchXMaterial(itemName);
 
 		if (item == null || !item.isPresent() || item.get() == null)
 			return;
 
-		XMaterial material = item.get();
+		XMaterialUtil material = item.get();
 
 		if (!ItemHandler.getInstance().getCachedMaterialSizes().containsKey(material))
 			return;
@@ -91,12 +91,12 @@ public class Commands implements Listener {
 
 		int amount = Integer.parseInt(command[3]);
 
-		Optional<XMaterial> item = XMaterial.matchXMaterial(itemName);
+		Optional<XMaterialUtil> item = XMaterialUtil.matchXMaterial(itemName);
 
 		if (item == null || !item.isPresent() || item.get() == null)
 			return;
 
-		XMaterial material = item.get();
+		XMaterialUtil material = item.get();
 
 		if (!ItemHandler.getInstance().getCachedMaterialSizes().containsKey(material))
 			return;

--- a/src/main/java/com/codingguru/inventorystacks/listeners/FurnaceBurn.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/FurnaceBurn.java
@@ -22,7 +22,7 @@ public class FurnaceBurn implements Listener {
 		if (e.getFuel().getAmount() <= 1)
 			return;
 
-		if (!ItemHandler.getInstance().getCachedMaterialSizes().containsKey(XMaterialUtil.LAVA_BUCKET))
+		if (!ItemHandler.getInstance().hasEditedStackSize(XMaterialUtil.LAVA_BUCKET))
 			return;
 
 		e.getBlock().getWorld().dropItem(e.getBlock().getLocation(), new ItemStack(Material.BUCKET));

--- a/src/main/java/com/codingguru/inventorystacks/listeners/FurnaceBurn.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/FurnaceBurn.java
@@ -7,7 +7,7 @@ import org.bukkit.event.inventory.FurnaceBurnEvent;
 import org.bukkit.inventory.ItemStack;
 
 import com.codingguru.inventorystacks.handlers.ItemHandler;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 
 public class FurnaceBurn implements Listener {
 
@@ -16,13 +16,13 @@ public class FurnaceBurn implements Listener {
 		if (e.getFuel() == null)
 			return;
 
-		if (e.getFuel().getType() != XMaterial.LAVA_BUCKET.get())
+		if (e.getFuel().getType() != XMaterialUtil.LAVA_BUCKET.get())
 			return;
 
 		if (e.getFuel().getAmount() <= 1)
 			return;
 
-		if (!ItemHandler.getInstance().getCachedMaterialSizes().containsKey(XMaterial.LAVA_BUCKET))
+		if (!ItemHandler.getInstance().getCachedMaterialSizes().containsKey(XMaterialUtil.LAVA_BUCKET))
 			return;
 
 		e.getBlock().getWorld().dropItem(e.getBlock().getLocation(), new ItemStack(Material.BUCKET));

--- a/src/main/java/com/codingguru/inventorystacks/listeners/InventoryClick.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/InventoryClick.java
@@ -44,7 +44,7 @@ public class InventoryClick implements Listener {
 		if (stack == null || stack.getType() == Material.AIR)
 			return;
 
-		if (!ItemHandler.getInstance().getCachedMaterialSizes().containsKey(XMaterialUtil.matchXMaterial(stack.getType())))
+		if (!ItemHandler.getInstance().hasEditedStackSize(stack.getType()))
 			return;
 
 		Inventory brewingInv = e.getInventory();
@@ -96,8 +96,7 @@ public class InventoryClick implements Listener {
 				&& !(e.getCursor() != null && e.getCursor().getType() != Material.AIR))
 			return;
 
-		if (!ItemHandler.getInstance().getCachedMaterialSizes()
-				.containsKey(XMaterialUtil.matchXMaterial(e.getCurrentItem().getType())))
+		if (!ItemHandler.getInstance().hasEditedStackSize(e.getCurrentItem().getType()))
 			return;
 
 		InventoryUpdateTask updateInventoryTask = new InventoryUpdateTask((Player) e.getWhoClicked());
@@ -115,7 +114,7 @@ public class InventoryClick implements Listener {
 		if (e.getSlotType() != SlotType.RESULT)
 			return;
 
-		if (!ItemHandler.getInstance().getCachedMaterialSizes().containsKey(XMaterialUtil.ENCHANTED_BOOK))
+		if (!ItemHandler.getInstance().hasEditedStackSize(XMaterialUtil.ENCHANTED_BOOK))
 			return;
 
 		ItemStack craftedItem = e.getInventory().getContents()[1];
@@ -153,9 +152,7 @@ public class InventoryClick implements Listener {
 		if (craftedItem.getAmount() <= 1)
 			return;
 
-		XMaterialUtil xMaterial = XMaterialUtil.matchXMaterial(craftedItem.getType());
-
-		if (!ItemHandler.getInstance().getCachedMaterialSizes().containsKey(xMaterial))
+		if (!ItemHandler.getInstance().hasEditedStackSize(craftedItem.getType()))
 			return;
 
 		e.getWhoClicked().closeInventory();

--- a/src/main/java/com/codingguru/inventorystacks/listeners/InventoryClick.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/InventoryClick.java
@@ -21,7 +21,7 @@ import com.codingguru.inventorystacks.scheduler.InventoryUpdateTask;
 import com.codingguru.inventorystacks.util.ItemUtil;
 import com.codingguru.inventorystacks.util.MessagesUtil;
 import com.codingguru.inventorystacks.util.VersionUtil;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 
 public class InventoryClick implements Listener {
 
@@ -44,7 +44,7 @@ public class InventoryClick implements Listener {
 		if (stack == null || stack.getType() == Material.AIR)
 			return;
 
-		if (!ItemHandler.getInstance().getCachedMaterialSizes().containsKey(XMaterial.matchXMaterial(stack.getType())))
+		if (!ItemHandler.getInstance().getCachedMaterialSizes().containsKey(XMaterialUtil.matchXMaterial(stack.getType())))
 			return;
 
 		Inventory brewingInv = e.getInventory();
@@ -97,7 +97,7 @@ public class InventoryClick implements Listener {
 			return;
 
 		if (!ItemHandler.getInstance().getCachedMaterialSizes()
-				.containsKey(XMaterial.matchXMaterial(e.getCurrentItem().getType())))
+				.containsKey(XMaterialUtil.matchXMaterial(e.getCurrentItem().getType())))
 			return;
 
 		InventoryUpdateTask updateInventoryTask = new InventoryUpdateTask((Player) e.getWhoClicked());
@@ -115,7 +115,7 @@ public class InventoryClick implements Listener {
 		if (e.getSlotType() != SlotType.RESULT)
 			return;
 
-		if (!ItemHandler.getInstance().getCachedMaterialSizes().containsKey(XMaterial.ENCHANTED_BOOK))
+		if (!ItemHandler.getInstance().getCachedMaterialSizes().containsKey(XMaterialUtil.ENCHANTED_BOOK))
 			return;
 
 		ItemStack craftedItem = e.getInventory().getContents()[1];
@@ -153,7 +153,7 @@ public class InventoryClick implements Listener {
 		if (craftedItem.getAmount() <= 1)
 			return;
 
-		XMaterial xMaterial = XMaterial.matchXMaterial(craftedItem.getType());
+		XMaterialUtil xMaterial = XMaterialUtil.matchXMaterial(craftedItem.getType());
 
 		if (!ItemHandler.getInstance().getCachedMaterialSizes().containsKey(xMaterial))
 			return;

--- a/src/main/java/com/codingguru/inventorystacks/listeners/InventoryMoveItem.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/InventoryMoveItem.java
@@ -11,7 +11,7 @@ import org.bukkit.inventory.ItemStack;
 import com.codingguru.inventorystacks.InventoryStacks;
 import com.codingguru.inventorystacks.handlers.ItemHandler;
 import com.codingguru.inventorystacks.scheduler.FixBrewingStandTask;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 
 public class InventoryMoveItem implements Listener {
 
@@ -28,7 +28,7 @@ public class InventoryMoveItem implements Listener {
 		if (it == null || it.getType() == Material.AIR)
 			return;
 
-		if (!ItemHandler.getInstance().getCachedMaterialSizes().containsKey(XMaterial.matchXMaterial(it.getType())))
+		if (!ItemHandler.getInstance().getCachedMaterialSizes().containsKey(XMaterialUtil.matchXMaterial(it.getType())))
 			return;
 
 		if (!isAnyPotion(it))
@@ -61,8 +61,8 @@ public class InventoryMoveItem implements Listener {
 
 	private boolean isAnyPotion(ItemStack item) {
 		Material t = item.getType();
-		return t == Material.POTION || (XMaterial.matchXMaterial("SPLASH_POTION").map(XMaterial::get).orElse(null) == t)
-				|| (XMaterial.matchXMaterial("LINGERING_POTION").map(XMaterial::get).orElse(null) == t);
+		return t == Material.POTION || (XMaterialUtil.matchXMaterial("SPLASH_POTION").map(XMaterialUtil::get).orElse(null) == t)
+				|| (XMaterialUtil.matchXMaterial("LINGERING_POTION").map(XMaterialUtil::get).orElse(null) == t);
 	}
 
 }

--- a/src/main/java/com/codingguru/inventorystacks/listeners/InventoryMoveItem.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/InventoryMoveItem.java
@@ -28,7 +28,7 @@ public class InventoryMoveItem implements Listener {
 		if (it == null || it.getType() == Material.AIR)
 			return;
 
-		if (!ItemHandler.getInstance().getCachedMaterialSizes().containsKey(XMaterialUtil.matchXMaterial(it.getType())))
+		if (!ItemHandler.getInstance().hasEditedStackSize(it.getType()))
 			return;
 
 		if (!isAnyPotion(it))

--- a/src/main/java/com/codingguru/inventorystacks/listeners/PlayerBucketEmpty.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/PlayerBucketEmpty.java
@@ -14,7 +14,7 @@ import org.bukkit.inventory.ItemStack;
 import com.codingguru.inventorystacks.scheduler.ChangeItemInHandTask;
 import com.codingguru.inventorystacks.scheduler.ChangeItemInHandWithItemTask;
 import com.codingguru.inventorystacks.util.VersionUtil;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 
 public class PlayerBucketEmpty implements Listener {
 
@@ -49,11 +49,11 @@ public class PlayerBucketEmpty implements Listener {
 
 		if (!VersionUtil.v1_21.isServerVersionHigher()) {
 			ChangeItemInHandWithItemTask changeItemTask = new ChangeItemInHandWithItemTask(e.getPlayer(), clone,
-					new ItemStack(XMaterial.BUCKET.get()), XMaterial.BUCKET.get());
+					new ItemStack(XMaterialUtil.BUCKET.get()), XMaterialUtil.BUCKET.get());
 			changeItemTask.runTaskLater(itemChangeDelay);
 		} else {
 			ChangeItemInHandTask changeItemTask = new ChangeItemInHandTask(e.getPlayer(), clone,
-					XMaterial.BUCKET.get());
+					XMaterialUtil.BUCKET.get());
 			changeItemTask.runTaskLater(itemChangeDelay);
 		}
 	}
@@ -89,7 +89,7 @@ public class PlayerBucketEmpty implements Listener {
 		remaining.setAmount(amount - 1);
 
 		ChangeItemInHandWithItemTask task = new ChangeItemInHandWithItemTask(player, remaining,
-				new ItemStack(Material.BUCKET), XMaterial.BUCKET.get());
+				new ItemStack(Material.BUCKET), XMaterialUtil.BUCKET.get());
 		task.runTaskLater(itemChangeDelay);
 	}
 

--- a/src/main/java/com/codingguru/inventorystacks/listeners/PlayerInteract.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/PlayerInteract.java
@@ -10,7 +10,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 
 import com.codingguru.inventorystacks.util.VersionUtil;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 
 public class PlayerInteract implements Listener {
 
@@ -22,10 +22,10 @@ public class PlayerInteract implements Listener {
 		if (e.getAction() != Action.RIGHT_CLICK_BLOCK)
 			return;
 
-		if (e.getClickedBlock().getType() != XMaterial.JUKEBOX.get())
+		if (e.getClickedBlock().getType() != XMaterialUtil.JUKEBOX.get())
 			return;
 
-		if (e.getItem() == null || e.getItem().getType() == XMaterial.AIR.get())
+		if (e.getItem() == null || e.getItem().getType() == XMaterialUtil.AIR.get())
 			return;
 
 		ItemStack holding = e.getItem();
@@ -52,13 +52,13 @@ public class PlayerInteract implements Listener {
 	}
 
 	private boolean isMusicDisc(Material type) {
-		return type == XMaterial.MUSIC_DISC_11.get() || type == XMaterial.MUSIC_DISC_13.get()
-				|| type == XMaterial.MUSIC_DISC_5.get() || type == XMaterial.MUSIC_DISC_BLOCKS.get()
-				|| type == XMaterial.MUSIC_DISC_CAT.get() || type == XMaterial.MUSIC_DISC_CHIRP.get()
-				|| type == XMaterial.MUSIC_DISC_FAR.get() || type == XMaterial.MUSIC_DISC_MALL.get()
-				|| type == XMaterial.MUSIC_DISC_MELLOHI.get() || type == XMaterial.MUSIC_DISC_OTHERSIDE.get()
-				|| type == XMaterial.MUSIC_DISC_PIGSTEP.get() || type == XMaterial.MUSIC_DISC_RELIC.get()
-				|| type == XMaterial.MUSIC_DISC_STAL.get() || type == XMaterial.MUSIC_DISC_STRAD.get()
-				|| type == XMaterial.MUSIC_DISC_WAIT.get() || type == XMaterial.MUSIC_DISC_WARD.get();
+		return type == XMaterialUtil.MUSIC_DISC_11.get() || type == XMaterialUtil.MUSIC_DISC_13.get()
+				|| type == XMaterialUtil.MUSIC_DISC_5.get() || type == XMaterialUtil.MUSIC_DISC_BLOCKS.get()
+				|| type == XMaterialUtil.MUSIC_DISC_CAT.get() || type == XMaterialUtil.MUSIC_DISC_CHIRP.get()
+				|| type == XMaterialUtil.MUSIC_DISC_FAR.get() || type == XMaterialUtil.MUSIC_DISC_MALL.get()
+				|| type == XMaterialUtil.MUSIC_DISC_MELLOHI.get() || type == XMaterialUtil.MUSIC_DISC_OTHERSIDE.get()
+				|| type == XMaterialUtil.MUSIC_DISC_PIGSTEP.get() || type == XMaterialUtil.MUSIC_DISC_RELIC.get()
+				|| type == XMaterialUtil.MUSIC_DISC_STAL.get() || type == XMaterialUtil.MUSIC_DISC_STRAD.get()
+				|| type == XMaterialUtil.MUSIC_DISC_WAIT.get() || type == XMaterialUtil.MUSIC_DISC_WARD.get();
 	}
 }

--- a/src/main/java/com/codingguru/inventorystacks/listeners/PlayerItemConsume.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/PlayerItemConsume.java
@@ -9,7 +9,7 @@ import org.bukkit.inventory.ItemStack;
 import com.codingguru.inventorystacks.scheduler.ChangeItemInHandWithItemTask;
 import com.codingguru.inventorystacks.util.ItemUtil;
 import com.codingguru.inventorystacks.util.VersionUtil;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 
 public class PlayerItemConsume implements Listener {
 
@@ -30,22 +30,22 @@ public class PlayerItemConsume implements Listener {
 		if (e.getItem().getAmount() <= 1)
 			return;
 
-		if (e.getItem().getType() == XMaterial.MILK_BUCKET.get()) {
-			ItemUtil.addItem(e.getPlayer(), new ItemStack(XMaterial.BUCKET.get()));
+		if (e.getItem().getType() == XMaterialUtil.MILK_BUCKET.get()) {
+			ItemUtil.addItem(e.getPlayer(), new ItemStack(XMaterialUtil.BUCKET.get()));
 			return;
 		}
 
-		if (e.getItem().getType() != XMaterial.RABBIT_STEW.get()
-				&& e.getItem().getType() != XMaterial.SUSPICIOUS_STEW.get()
-				&& e.getItem().getType() != XMaterial.MUSHROOM_STEW.get()
-				&& e.getItem().getType() != XMaterial.BEETROOT_SOUP.get())
+		if (e.getItem().getType() != XMaterialUtil.RABBIT_STEW.get()
+				&& e.getItem().getType() != XMaterialUtil.SUSPICIOUS_STEW.get()
+				&& e.getItem().getType() != XMaterialUtil.MUSHROOM_STEW.get()
+				&& e.getItem().getType() != XMaterialUtil.BEETROOT_SOUP.get())
 			return;
 
 		ItemStack clone = e.getItem().clone();
 		clone.setAmount(e.getItem().getAmount() - 1);
 
 		ChangeItemInHandWithItemTask changeItemTask = new ChangeItemInHandWithItemTask(e.getPlayer(), clone,
-				new ItemStack(XMaterial.BOWL.get()), XMaterial.BOWL.get());
+				new ItemStack(XMaterialUtil.BOWL.get()), XMaterialUtil.BOWL.get());
 		changeItemTask.runTaskLater(itemChangeDelay);
 	}
 

--- a/src/main/java/com/codingguru/inventorystacks/listeners/PlayerItemDamage.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/PlayerItemDamage.java
@@ -8,7 +8,7 @@ import org.bukkit.inventory.ItemStack;
 
 import com.codingguru.inventorystacks.handlers.ItemHandler;
 import com.codingguru.inventorystacks.scheduler.DamageItemTask;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 
 public class PlayerItemDamage implements Listener {
 
@@ -25,7 +25,7 @@ public class PlayerItemDamage implements Listener {
 		if (originalAmount <= 1)
 			return;
 
-		XMaterial xMat = XMaterial.matchXMaterial(e.getItem().getType());
+		XMaterialUtil xMat = XMaterialUtil.matchXMaterial(e.getItem().getType());
 
 		if (!ItemHandler.getInstance().getCachedMaterialSizes().containsKey(xMat))
 			return;

--- a/src/main/java/com/codingguru/inventorystacks/listeners/PlayerItemDamage.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/PlayerItemDamage.java
@@ -8,7 +8,6 @@ import org.bukkit.inventory.ItemStack;
 
 import com.codingguru.inventorystacks.handlers.ItemHandler;
 import com.codingguru.inventorystacks.scheduler.DamageItemTask;
-import com.codingguru.inventorystacks.util.XMaterialUtil;
 
 public class PlayerItemDamage implements Listener {
 
@@ -25,9 +24,7 @@ public class PlayerItemDamage implements Listener {
 		if (originalAmount <= 1)
 			return;
 
-		XMaterialUtil xMat = XMaterialUtil.matchXMaterial(e.getItem().getType());
-
-		if (!ItemHandler.getInstance().getCachedMaterialSizes().containsKey(xMat))
+		if (!ItemHandler.getInstance().hasEditedStackSize(e.getItem().getType()))
 			return;
 
 		ItemStack clone = e.getItem().clone();

--- a/src/main/java/com/codingguru/inventorystacks/listeners/correction/BlockDispense.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/correction/BlockDispense.java
@@ -18,7 +18,7 @@ import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionType;
 
 import com.codingguru.inventorystacks.util.VersionUtil;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 
 public class BlockDispense implements Listener {
 
@@ -46,7 +46,7 @@ public class BlockDispense implements Listener {
 
 		e.setCancelled(true);
 
-		Material mud = XMaterial.matchXMaterial("MUD").map(XMaterial::get).orElse(null);
+		Material mud = XMaterialUtil.matchXMaterial("MUD").map(XMaterialUtil::get).orElse(null);
 		if (mud == null)
 			return;
 
@@ -66,7 +66,7 @@ public class BlockDispense implements Listener {
 		inSlot.setAmount(inSlot.getAmount() - 1);
 		inv.setItem(slot, inSlot.getAmount() > 0 ? inSlot : null);
 
-		Material glassBottle = XMaterial.matchXMaterial("GLASS_BOTTLE").map(XMaterial::get).orElse(null);
+		Material glassBottle = XMaterialUtil.matchXMaterial("GLASS_BOTTLE").map(XMaterialUtil::get).orElse(null);
 		if (glassBottle != null) {
 			Map<Integer, ItemStack> overflow = inv.addItem(new ItemStack(glassBottle, 1));
 			overflow.values().forEach(item -> dispenserBlock.getWorld()
@@ -79,7 +79,7 @@ public class BlockDispense implements Listener {
 		if (item == null)
 			return false;
 
-		if (item.getType() != XMaterial.matchXMaterial("POTION").map(XMaterial::get).orElse(null))
+		if (item.getType() != XMaterialUtil.matchXMaterial("POTION").map(XMaterialUtil::get).orElse(null))
 			return false;
 
 		if (!(item.getItemMeta() instanceof PotionMeta))

--- a/src/main/java/com/codingguru/inventorystacks/listeners/correction/FurnaceBurn.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/correction/FurnaceBurn.java
@@ -7,7 +7,7 @@ import org.bukkit.event.inventory.FurnaceBurnEvent;
 import org.bukkit.inventory.ItemStack;
 
 import com.codingguru.inventorystacks.handlers.ItemHandler;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 
 public class FurnaceBurn implements Listener {
 
@@ -16,13 +16,13 @@ public class FurnaceBurn implements Listener {
 		if (e.getFuel() == null)
 			return;
 
-		if (e.getFuel().getType() != XMaterial.LAVA_BUCKET.get())
+		if (e.getFuel().getType() != XMaterialUtil.LAVA_BUCKET.get())
 			return;
 
 		if (e.getFuel().getAmount() <= 1)
 			return;
 
-		if (!ItemHandler.getInstance().hasEditedStackSize(XMaterial.LAVA_BUCKET))
+		if (!ItemHandler.getInstance().hasEditedStackSize(XMaterialUtil.LAVA_BUCKET))
 			return;
 
 		e.getBlock().getWorld().dropItem(e.getBlock().getLocation(), new ItemStack(Material.BUCKET));

--- a/src/main/java/com/codingguru/inventorystacks/listeners/correction/InventoryClick.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/correction/InventoryClick.java
@@ -21,7 +21,7 @@ import com.codingguru.inventorystacks.scheduler.InventoryUpdateTask;
 import com.codingguru.inventorystacks.util.ItemUtil;
 import com.codingguru.inventorystacks.util.MessagesUtil;
 import com.codingguru.inventorystacks.util.VersionUtil;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 
 public class InventoryClick implements Listener {
 
@@ -114,7 +114,7 @@ public class InventoryClick implements Listener {
 		if (e.getSlotType() != SlotType.RESULT)
 			return;
 
-		if (!ItemHandler.getInstance().hasEditedStackSize(XMaterial.ENCHANTED_BOOK))
+		if (!ItemHandler.getInstance().hasEditedStackSize(XMaterialUtil.ENCHANTED_BOOK))
 			return;
 
 		ItemStack craftedItem = e.getInventory().getContents()[1];

--- a/src/main/java/com/codingguru/inventorystacks/listeners/correction/InventoryMoveItem.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/correction/InventoryMoveItem.java
@@ -11,7 +11,7 @@ import org.bukkit.inventory.ItemStack;
 import com.codingguru.inventorystacks.InventoryStacks;
 import com.codingguru.inventorystacks.handlers.ItemHandler;
 import com.codingguru.inventorystacks.scheduler.FixBrewingStandTask;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 
 public class InventoryMoveItem implements Listener {
 
@@ -61,8 +61,8 @@ public class InventoryMoveItem implements Listener {
 
 	private boolean isAnyPotion(ItemStack item) {
 		Material t = item.getType();
-		return t == Material.POTION || (XMaterial.matchXMaterial("SPLASH_POTION").map(XMaterial::get).orElse(null) == t)
-				|| (XMaterial.matchXMaterial("LINGERING_POTION").map(XMaterial::get).orElse(null) == t);
+		return t == Material.POTION || (XMaterialUtil.matchXMaterial("SPLASH_POTION").map(XMaterialUtil::get).orElse(null) == t)
+				|| (XMaterialUtil.matchXMaterial("LINGERING_POTION").map(XMaterialUtil::get).orElse(null) == t);
 	}
 
 }

--- a/src/main/java/com/codingguru/inventorystacks/listeners/correction/PlayerBucketEmpty.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/correction/PlayerBucketEmpty.java
@@ -14,7 +14,7 @@ import org.bukkit.inventory.ItemStack;
 import com.codingguru.inventorystacks.scheduler.ChangeItemInHandTask;
 import com.codingguru.inventorystacks.scheduler.ChangeItemInHandWithItemTask;
 import com.codingguru.inventorystacks.util.VersionUtil;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 
 public class PlayerBucketEmpty implements Listener {
 
@@ -49,11 +49,11 @@ public class PlayerBucketEmpty implements Listener {
 
 		if (!VersionUtil.v1_21.isServerVersionHigher()) {
 			ChangeItemInHandWithItemTask changeItemTask = new ChangeItemInHandWithItemTask(e.getPlayer(), clone,
-					new ItemStack(XMaterial.BUCKET.get()), XMaterial.BUCKET.get());
+					new ItemStack(XMaterialUtil.BUCKET.get()), XMaterialUtil.BUCKET.get());
 			changeItemTask.runTaskLater(itemChangeDelay);
 		} else {
 			ChangeItemInHandTask changeItemTask = new ChangeItemInHandTask(e.getPlayer(), clone,
-					XMaterial.BUCKET.get());
+					XMaterialUtil.BUCKET.get());
 			changeItemTask.runTaskLater(itemChangeDelay);
 		}
 	}
@@ -89,7 +89,7 @@ public class PlayerBucketEmpty implements Listener {
 		remaining.setAmount(amount - 1);
 
 		ChangeItemInHandWithItemTask task = new ChangeItemInHandWithItemTask(player, remaining,
-				new ItemStack(Material.BUCKET), XMaterial.BUCKET.get());
+				new ItemStack(Material.BUCKET), XMaterialUtil.BUCKET.get());
 		task.runTaskLater(itemChangeDelay);
 	}
 

--- a/src/main/java/com/codingguru/inventorystacks/listeners/correction/PlayerInteract.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/correction/PlayerInteract.java
@@ -10,7 +10,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 
 import com.codingguru.inventorystacks.util.VersionUtil;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 
 public class PlayerInteract implements Listener {
 
@@ -22,10 +22,10 @@ public class PlayerInteract implements Listener {
 		if (e.getAction() != Action.RIGHT_CLICK_BLOCK)
 			return;
 
-		if (e.getClickedBlock().getType() != XMaterial.JUKEBOX.get())
+		if (e.getClickedBlock().getType() != XMaterialUtil.JUKEBOX.get())
 			return;
 
-		if (e.getItem() == null || e.getItem().getType() == XMaterial.AIR.get())
+		if (e.getItem() == null || e.getItem().getType() == XMaterialUtil.AIR.get())
 			return;
 
 		ItemStack holding = e.getItem();
@@ -52,13 +52,13 @@ public class PlayerInteract implements Listener {
 	}
 
 	private boolean isMusicDisc(Material type) {
-		return type == XMaterial.MUSIC_DISC_11.get() || type == XMaterial.MUSIC_DISC_13.get()
-				|| type == XMaterial.MUSIC_DISC_5.get() || type == XMaterial.MUSIC_DISC_BLOCKS.get()
-				|| type == XMaterial.MUSIC_DISC_CAT.get() || type == XMaterial.MUSIC_DISC_CHIRP.get()
-				|| type == XMaterial.MUSIC_DISC_FAR.get() || type == XMaterial.MUSIC_DISC_MALL.get()
-				|| type == XMaterial.MUSIC_DISC_MELLOHI.get() || type == XMaterial.MUSIC_DISC_OTHERSIDE.get()
-				|| type == XMaterial.MUSIC_DISC_PIGSTEP.get() || type == XMaterial.MUSIC_DISC_RELIC.get()
-				|| type == XMaterial.MUSIC_DISC_STAL.get() || type == XMaterial.MUSIC_DISC_STRAD.get()
-				|| type == XMaterial.MUSIC_DISC_WAIT.get() || type == XMaterial.MUSIC_DISC_WARD.get();
+		return type == XMaterialUtil.MUSIC_DISC_11.get() || type == XMaterialUtil.MUSIC_DISC_13.get()
+				|| type == XMaterialUtil.MUSIC_DISC_5.get() || type == XMaterialUtil.MUSIC_DISC_BLOCKS.get()
+				|| type == XMaterialUtil.MUSIC_DISC_CAT.get() || type == XMaterialUtil.MUSIC_DISC_CHIRP.get()
+				|| type == XMaterialUtil.MUSIC_DISC_FAR.get() || type == XMaterialUtil.MUSIC_DISC_MALL.get()
+				|| type == XMaterialUtil.MUSIC_DISC_MELLOHI.get() || type == XMaterialUtil.MUSIC_DISC_OTHERSIDE.get()
+				|| type == XMaterialUtil.MUSIC_DISC_PIGSTEP.get() || type == XMaterialUtil.MUSIC_DISC_RELIC.get()
+				|| type == XMaterialUtil.MUSIC_DISC_STAL.get() || type == XMaterialUtil.MUSIC_DISC_STRAD.get()
+				|| type == XMaterialUtil.MUSIC_DISC_WAIT.get() || type == XMaterialUtil.MUSIC_DISC_WARD.get();
 	}
 }

--- a/src/main/java/com/codingguru/inventorystacks/listeners/correction/PlayerItemConsume.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/correction/PlayerItemConsume.java
@@ -9,7 +9,7 @@ import org.bukkit.inventory.ItemStack;
 import com.codingguru.inventorystacks.scheduler.ChangeItemInHandWithItemTask;
 import com.codingguru.inventorystacks.util.ItemUtil;
 import com.codingguru.inventorystacks.util.VersionUtil;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 
 public class PlayerItemConsume implements Listener {
 
@@ -30,22 +30,22 @@ public class PlayerItemConsume implements Listener {
 		if (e.getItem().getAmount() <= 1)
 			return;
 
-		if (e.getItem().getType() == XMaterial.MILK_BUCKET.get()) {
-			ItemUtil.addItem(e.getPlayer(), new ItemStack(XMaterial.BUCKET.get()));
+		if (e.getItem().getType() == XMaterialUtil.MILK_BUCKET.get()) {
+			ItemUtil.addItem(e.getPlayer(), new ItemStack(XMaterialUtil.BUCKET.get()));
 			return;
 		}
 
-		if (e.getItem().getType() != XMaterial.RABBIT_STEW.get()
-				&& e.getItem().getType() != XMaterial.SUSPICIOUS_STEW.get()
-				&& e.getItem().getType() != XMaterial.MUSHROOM_STEW.get()
-				&& e.getItem().getType() != XMaterial.BEETROOT_SOUP.get())
+		if (e.getItem().getType() != XMaterialUtil.RABBIT_STEW.get()
+				&& e.getItem().getType() != XMaterialUtil.SUSPICIOUS_STEW.get()
+				&& e.getItem().getType() != XMaterialUtil.MUSHROOM_STEW.get()
+				&& e.getItem().getType() != XMaterialUtil.BEETROOT_SOUP.get())
 			return;
 
 		ItemStack clone = e.getItem().clone();
 		clone.setAmount(e.getItem().getAmount() - 1);
 
 		ChangeItemInHandWithItemTask changeItemTask = new ChangeItemInHandWithItemTask(e.getPlayer(), clone,
-				new ItemStack(XMaterial.BOWL.get()), XMaterial.BOWL.get());
+				new ItemStack(XMaterialUtil.BOWL.get()), XMaterialUtil.BOWL.get());
 		changeItemTask.runTaskLater(itemChangeDelay);
 	}
 

--- a/src/main/java/com/codingguru/inventorystacks/listeners/general/BlockPlace.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/general/BlockPlace.java
@@ -9,7 +9,7 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 
 import com.codingguru.inventorystacks.scheduler.ChangeItemInHandWithItemTask;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 
 public class BlockPlace implements Listener {
 
@@ -30,7 +30,7 @@ public class BlockPlace implements Listener {
 			holding = player.getInventory().getItemInOffHand();
 		}
 
-		if (holding.getType() != XMaterial.POWDER_SNOW_BUCKET.get())
+		if (holding.getType() != XMaterialUtil.POWDER_SNOW_BUCKET.get())
 			return;
 
 		int amount = holding.getAmount();
@@ -42,7 +42,7 @@ public class BlockPlace implements Listener {
 		clone.setAmount(amount - 1);
 
 		ChangeItemInHandWithItemTask changeItemTask = new ChangeItemInHandWithItemTask(e.getPlayer(), clone,
-				new ItemStack(XMaterial.BUCKET.get()), XMaterial.BUCKET.get());
+				new ItemStack(XMaterialUtil.BUCKET.get()), XMaterialUtil.BUCKET.get());
 		changeItemTask.runTaskLater(itemChangeDelay);
 	}
 }

--- a/src/main/java/com/codingguru/inventorystacks/listeners/general/Commands.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/general/Commands.java
@@ -18,7 +18,7 @@ import com.codingguru.inventorystacks.util.DamageableUtil;
 import com.codingguru.inventorystacks.util.ItemUtil;
 import com.codingguru.inventorystacks.util.MessagesUtil;
 import com.codingguru.inventorystacks.util.RandomUtil;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 import com.google.common.collect.Lists;
 
 public class Commands implements Listener {
@@ -47,12 +47,12 @@ public class Commands implements Listener {
 			return;
 		}
 		
-		Optional<XMaterial> item = XMaterial.matchXMaterial(itemName);
+		Optional<XMaterialUtil> item = XMaterialUtil.matchXMaterial(itemName);
 
 		if (item == null || !item.isPresent() || item.get() == null)
 			return;
 
-		XMaterial material = item.get();
+		XMaterialUtil material = item.get();
 
 		if (!ItemHandler.getInstance().hasEditedStackSize(material))
 			return;
@@ -105,12 +105,12 @@ public class Commands implements Listener {
 			return;
 		}
 
-		Optional<XMaterial> item = XMaterial.matchXMaterial(itemName);
+		Optional<XMaterialUtil> item = XMaterialUtil.matchXMaterial(itemName);
 
 		if (item == null || !item.isPresent() || item.get() == null)
 			return;
 
-		XMaterial material = item.get();
+		XMaterialUtil material = item.get();
 
 		if (!ItemHandler.getInstance().hasEditedStackSize(material))
 			return;

--- a/src/main/java/com/codingguru/inventorystacks/listeners/general/TotemOffhandLimit.java
+++ b/src/main/java/com/codingguru/inventorystacks/listeners/general/TotemOffhandLimit.java
@@ -1,0 +1,175 @@
+package com.codingguru.inventorystacks.listeners.general;
+
+import java.util.Map;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryAction;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+
+import com.codingguru.inventorystacks.handlers.ItemHandler;
+
+public class TotemOffhandLimit implements Listener {
+
+	private static final int OFFHAND_SLOT = 40;
+
+	@EventHandler(ignoreCancelled = true)
+	public void onInventoryClick(InventoryClickEvent e) {
+		if (!(e.getWhoClicked() instanceof Player))
+			return;
+
+		if (!isStackedTotemEnabled())
+			return;
+
+		Player player = (Player) e.getWhoClicked();
+
+		if (e.getClick() == ClickType.SWAP_OFFHAND) {
+			handleSwapOffhandClick(e, player);
+			return;
+		}
+
+		if (isOffhandSlotClick(e)) {
+			handleDirectOffhandClick(e, player);
+			return;
+		}
+
+		if (e.getAction() == InventoryAction.MOVE_TO_OTHER_INVENTORY) {
+			handleShiftMoveToOffhand(e, player);
+		}
+	}
+
+	@EventHandler(ignoreCancelled = true)
+	public void onInventoryDrag(InventoryDragEvent e) {
+		if (!(e.getWhoClicked() instanceof Player))
+			return;
+
+		if (!isStackedTotemEnabled())
+			return;
+
+		for (Map.Entry<Integer, ItemStack> entry : e.getNewItems().entrySet()) {
+			if (!isOffhandRawSlot(e, entry.getKey()))
+				continue;
+
+			ItemStack item = entry.getValue();
+			if (isTotem(item) && item.getAmount() > 1) {
+				e.setCancelled(true);
+				return;
+			}
+		}
+	}
+
+	private void handleSwapOffhandClick(InventoryClickEvent e, Player player) {
+		ItemStack moving = e.getCurrentItem();
+
+		if (!isTotem(moving) || moving.getAmount() <= 1)
+			return;
+
+		e.setCancelled(true);
+
+		PlayerInventory inventory = player.getInventory();
+		if (!isEmpty(inventory.getItemInOffHand()))
+			return;
+
+		inventory.setItemInOffHand(singleTotem(moving));
+		decreaseCurrentItem(e, moving);
+		player.updateInventory();
+	}
+
+	private void handleDirectOffhandClick(InventoryClickEvent e, Player player) {
+		ItemStack cursor = e.getCursor();
+		ItemStack current = e.getCurrentItem();
+
+		if (!isTotem(cursor))
+			return;
+
+		if (cursor.getAmount() <= 1 && isEmpty(current))
+			return;
+
+		if (cursor.getAmount() > 1 && isEmpty(current) && e.getClick() == ClickType.RIGHT)
+			return;
+
+		e.setCancelled(true);
+
+		if (!isEmpty(current))
+			return;
+
+		player.getInventory().setItemInOffHand(singleTotem(cursor));
+		decreaseCursor(e, cursor);
+		player.updateInventory();
+	}
+
+	private void handleShiftMoveToOffhand(InventoryClickEvent e, Player player) {
+		ItemStack moving = e.getCurrentItem();
+
+		if (!isTotem(moving) || moving.getAmount() <= 1)
+			return;
+
+		if (!isEmpty(player.getInventory().getItemInOffHand()))
+			return;
+
+		e.setCancelled(true);
+		player.getInventory().setItemInOffHand(singleTotem(moving));
+		decreaseCurrentItem(e, moving);
+		player.updateInventory();
+	}
+
+	private boolean isOffhandSlotClick(InventoryClickEvent e) {
+		return e.getClickedInventory() instanceof PlayerInventory && e.getSlot() == OFFHAND_SLOT;
+	}
+
+	private boolean isOffhandRawSlot(InventoryDragEvent e, int rawSlot) {
+		Inventory topInventory = e.getView().getTopInventory();
+		return rawSlot >= topInventory.getSize() && e.getView().convertSlot(rawSlot) == OFFHAND_SLOT;
+	}
+
+	private boolean isStackedTotemEnabled() {
+		return ItemHandler.getInstance().hasEditedStackSize(Material.TOTEM_OF_UNDYING);
+	}
+
+	private boolean isTotem(ItemStack item) {
+		return item != null && item.getType() == Material.TOTEM_OF_UNDYING;
+	}
+
+	private boolean isEmpty(ItemStack item) {
+		return item == null || item.getType() == Material.AIR;
+	}
+
+	private ItemStack singleTotem(ItemStack source) {
+		ItemStack one = source.clone();
+		one.setAmount(1);
+		return one;
+	}
+
+	private void decreaseCurrentItem(InventoryClickEvent e, ItemStack source) {
+		int newAmount = source.getAmount() - 1;
+
+		if (newAmount <= 0) {
+			e.setCurrentItem(null);
+			return;
+		}
+
+		ItemStack remaining = source.clone();
+		remaining.setAmount(newAmount);
+		e.setCurrentItem(remaining);
+	}
+
+	private void decreaseCursor(InventoryClickEvent e, ItemStack source) {
+		int newAmount = source.getAmount() - 1;
+
+		if (newAmount <= 0) {
+			e.setCursor(null);
+			return;
+		}
+
+		ItemStack remaining = source.clone();
+		remaining.setAmount(newAmount);
+		e.setCursor(remaining);
+	}
+}

--- a/src/main/java/com/codingguru/inventorystacks/util/ConsoleUtil.java
+++ b/src/main/java/com/codingguru/inventorystacks/util/ConsoleUtil.java
@@ -42,4 +42,16 @@ public class ConsoleUtil {
 	public static void warning(String message) {
 		CONSOLE.sendMessage(ChatColor.RED + message);
 	}
+
+	public static void debug(String message) {
+		InventoryStacks plugin = InventoryStacks.getInstance();
+
+		if (plugin == null)
+			return;
+
+		if (!plugin.getConfig().getBoolean("debug-mode", false))
+			return;
+
+		CONSOLE.sendMessage(ChatColor.GRAY + "[InventoryStacks-Debug] " + ChatColor.WHITE + message);
+	}
 }

--- a/src/main/java/com/codingguru/inventorystacks/util/ReflectionUtil.java
+++ b/src/main/java/com/codingguru/inventorystacks/util/ReflectionUtil.java
@@ -19,7 +19,7 @@ import org.bukkit.Material;
 
 import com.codingguru.inventorystacks.InventoryStacks;
 import com.codingguru.inventorystacks.handlers.ItemHandler;
-import com.cryptomorin.xseries.XMaterial;
+import com.codingguru.inventorystacks.util.XMaterialUtil;
 
 @SuppressWarnings("deprecation")
 public final class ReflectionUtil {
@@ -60,7 +60,7 @@ public final class ReflectionUtil {
 				String matName = e.getKey();
 				int size = e.getValue();
 
-				XMaterial xMat = XMaterial.matchXMaterial(matName).orElse(null);
+				XMaterialUtil xMat = XMaterialUtil.matchXMaterial(matName).orElse(null);
 
 				if (xMat == null) {
 					ConsoleUtil.warning(ChatColor.RED + "The Item: " + matName
@@ -101,7 +101,7 @@ public final class ReflectionUtil {
 
 	private static Map<String, Integer> resolveConfiguredItems(Collection<String> keys) {
 		Map<String, Integer> resolved = new HashMap<>();
-		XMaterial[] allMaterials = XMaterial.VALUES;
+		XMaterialUtil[] allMaterials = XMaterialUtil.VALUES;
 
 		for (String key : keys) {
 			if (key == null)
@@ -124,7 +124,7 @@ public final class ReflectionUtil {
 				continue;
 			}
 
-			for (XMaterial material : allMaterials) {
+			for (XMaterialUtil material : allMaterials) {
 				String name = material.name();
 
 				if (pattern.matcher(name).matches()) {
@@ -139,7 +139,7 @@ public final class ReflectionUtil {
 	private static void updateAllItems(Set<String> exemptMaterials, int stackSize) {
 		Set<Material> processed = new HashSet<>();
 
-		for (XMaterial xMat : XMaterial.VALUES) {
+		for (XMaterialUtil xMat : XMaterialUtil.VALUES) {
 			if (!xMat.isSupported())
 				continue;
 

--- a/src/main/java/com/codingguru/inventorystacks/util/StackSizeApplierUtil.java
+++ b/src/main/java/com/codingguru/inventorystacks/util/StackSizeApplierUtil.java
@@ -1,5 +1,6 @@
 package com.codingguru.inventorystacks.util;
 
+import org.bukkit.Bukkit;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import com.codingguru.inventorystacks.InventoryStacks;
@@ -10,12 +11,29 @@ import com.codingguru.inventorystacks.items.StackSizeApplier;
 public final class StackSizeApplierUtil {
 
 	public static StackSizeApplier create() {
-		if (hasItemMetaSetMaxStackSize()
-				&& !InventoryStacks.getInstance().getConfig().getBoolean("use-legacy-reflection", false)) {
+		if (hasItemMetaSetMaxStackSize() && !shouldUseLegacyReflection()) {
 			return new ItemMetaStackSizeApplier();
 		}
 
 		return new LegacyNmsStackSizeApplier();
+	}
+
+	public static boolean shouldUseLegacyReflection() {
+		if (InventoryStacks.getInstance().getConfig().getBoolean("use-legacy-reflection", false))
+			return true;
+
+		return isGeyserCompatibilityEnabled() && isGeyserPresent();
+	}
+
+	public static boolean isGeyserCompatibilityEnabled() {
+		return InventoryStacks.getInstance().getConfig().getBoolean("geyser-support.auto-use-legacy-reflection", true);
+	}
+
+	public static boolean isGeyserPresent() {
+		return Bukkit.getPluginManager().getPlugin("Geyser-Spigot") != null
+				|| Bukkit.getPluginManager().getPlugin("Geyser-Bukkit") != null
+				|| Bukkit.getPluginManager().getPlugin("GeyserMC") != null
+				|| Bukkit.getPluginManager().getPlugin("floodgate") != null;
 	}
 
 	private static boolean hasItemMetaSetMaxStackSize() {

--- a/src/main/java/com/codingguru/inventorystacks/util/VersionUtil.java
+++ b/src/main/java/com/codingguru/inventorystacks/util/VersionUtil.java
@@ -35,7 +35,9 @@ public enum VersionUtil {
 
     v1_20("net.minecraft.world.item.Item", "net.minecraft.world.item.Items", "d", 99, 22),
 
-    v1_21("net.minecraft.world.item.Item", "net.minecraft.world.item.Items", null, 99, 23);
+    v1_21("net.minecraft.world.item.Item", "net.minecraft.world.item.Items", null, 99, 23),
+
+    v1_26("net.minecraft.world.item.Item", "net.minecraft.world.item.Items", null, 99, 24);
 
     private final String itemClass;
     private final String itemsClass;

--- a/src/main/java/com/codingguru/inventorystacks/util/XMaterialUtil.java
+++ b/src/main/java/com/codingguru/inventorystacks/util/XMaterialUtil.java
@@ -2304,6 +2304,16 @@ public enum XMaterialUtil {
     }
 
     /**
+     * Gets the material for this XMaterialUtil.
+     *
+     * @return the parsed Bukkit material or null if unsupported.
+     */
+    @Nullable
+    public Material get() {
+        return this.parseMaterial();
+    }
+
+    /**
      * Checks if an item has the same material (and data value on older versions).
      *
      * @param item item to check.
@@ -2430,10 +2440,17 @@ public enum XMaterialUtil {
 
         static { // This needs to be right below VERSION because of initialization order.
             String version = Bukkit.getVersion();
-            Matcher matcher = Pattern.compile("MC: \\d\\.(\\d+)").matcher(version);
+            Matcher matcher = Pattern.compile("MC: (\\d+)(?:\\.(\\d+))?").matcher(version);
 
-            if (matcher.find()) VERSION = Integer.parseInt(matcher.group(1));
-            else throw new IllegalArgumentException("Failed to parse server version from: " + version);
+            if (matcher.find()) {
+                int major = Integer.parseInt(matcher.group(1));
+                String minorGroup = matcher.group(2);
+
+                // Older versions use 1.x, while newer versions may use x.y.z.
+                VERSION = major == 1 && minorGroup != null ? Integer.parseInt(minorGroup) : major;
+            } else {
+                throw new IllegalArgumentException("Failed to parse server version from: " + version);
+            }
         }
 
         /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -49,10 +49,17 @@ max-stack-for-all-items:
 
 # Max Item Stack Sizes
 # Format = MATERIAL NAME : STACK SIZE
+# Supports exact item names, regex, and predefined groups:
+# BEDS, POTIONS, STEWS, BUCKETS, BOATS
 # (This list of items will also work with max-stack-for-all-items if enabled)
 
 items:
   POTION: 16
+  # BEDS: 16
+  # POTIONS: 16
+  # STEWS: 16
+  # BUCKETS: 16
+  # BOATS: 16
   # SPLASH_POTION: 16
 
 ############################################################################

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -30,6 +30,14 @@ stack-command:
   
 use-legacy-reflection: false
 
+# Bedrock clients connected through Geyser/Floodgate are more reliable with
+# global Material stack sizes than per-item ItemMeta stack size components.
+# When TRUE and Geyser/Floodgate is installed, this automatically uses legacy
+# reflection stack handling even on Minecraft 1.20.5+.
+
+geyser-support:
+  auto-use-legacy-reflection: true
+
 # Minecraft 1.20.5+ ONLY
 # This setting only applies when "use-legacy-reflection" is false
 # When TRUE, an item that is not listed in "items" section, it will reset to default vanilla amount
@@ -54,7 +62,10 @@ max-stack-for-all-items:
 # Max Item Stack Sizes
 # Format = MATERIAL NAME : STACK SIZE
 # Supports exact item names, regex, and predefined groups:
-# BEDS, POTIONS, STEWS, BUCKETS, BOATS
+# BEDS, POTIONS, STEWS, BUCKETS, BOATS, MINECARTS, TOOLS, WEAPONS,
+# ARMOR, HORSE_ARMOR, DYES, SIGNS, DOORS, TRAPDOORS, BUTTONS,
+# PRESSURE_PLATES, FENCES, SLABS, STAIRS, WALLS, CARPETS, BANNERS,
+# MUSIC_DISCS, SPAWN_EGGS, ARROWS, FIREWORKS, FOOD
 # (This list of items will also work with max-stack-for-all-items if enabled)
 
 items:
@@ -64,6 +75,12 @@ items:
   # STEWS: 16
   # BUCKETS: 16
   # BOATS: 16
+  # MINECARTS: 16
+  # TOOLS: 1
+  # WEAPONS: 1
+  # ARMOR: 1
+  # MUSIC_DISCS: 16
+  # SPAWN_EGGS: 16
   # SPLASH_POTION: 16
 
 ############################################################################

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,6 +2,10 @@
 
 check-for-updates: true # Check for new plugin updates
 
+# Enables extra console logging for troubleshooting
+# Recommended to keep false unless actively debugging
+debug-mode: false
+
 # Use mini messages
 # Allows for clickable links, actions and more.
 # https://www.spigotmc.org/threads/minimessage-rich-text-messages-made-easy.433454/

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,7 @@ api-version: 1.13
 main: com.codingguru.inventorystacks.InventoryStacks
 authors: [CodingGuru]
 folia-supported: true
+softdepend: [Geyser-Spigot, Geyser-Bukkit, GeyserMC, floodgate]
 commands:
     stack:
      description: Stack all items in your inventory.


### PR DESCRIPTION
# Add Minecraft 26.1.x support and built-in item group aliases for config

- Added explicit support for Minecraft `26.1`, `26.1.1`, and `26.1.2` server versions.
- Extended `VersionUtil` and server version detection in `ItemHandler` to recognize 26.x runtime versions.
- Added built-in item group aliases in `ItemHandler`:
  - `BEDS`
  - `POTIONS`
  - `STEWS`
  - `BUCKETS`
  - `BOATS`
- Updated config.yml documentation with group alias examples so users can configure groups directly.
- Verified build success with `mvn -DskipTests package`.You've used 63% of your weekly rate limit. Your weekly rate limit will reset on April 27 at 2:00 AM. [Learn More](https://aka.ms/github-copilot-rate-limit-error)